### PR TITLE
fixed typo in linked-list.mdx

### DIFF
--- a/src/content/data-structures/linked-list.mdx
+++ b/src/content/data-structures/linked-list.mdx
@@ -96,7 +96,7 @@ while node: # `node` 변수에 저장된 노드가 있는 동안 반복
 
 링크드 리스트의 기초를 다지시는데 아래 문제를 추천드리겠습니다.
 
-- [Valid Parentheses](/problems/add-two-numbers/)
+- [Add Two Numbers](/problems/add-two-numbers/)
 - [Generate Parentheses](/problems/generate-parentheses/)
 - [Same Tree](/problems/same-tree/)
 - [Invert Binary Tree](/problems/invert-binary-tree/)


### PR DESCRIPTION
자료구조 링크드 리스트 하단에 Add-Two-Numbers 페이지로 가는 링크명이 Valid-Parentheses로 되어 있어서 오타 수정 제안드립니다.