### PR TITLE
Longest Repeating Character Replacement 문제의 최적화 풀이 개선점

### DIFF
--- a/src/content/problems/longest-repeating-character-replacement.md
+++ b/src/content/problems/longest-repeating-character-replacement.md
@@ -240,7 +240,7 @@ class Solution:
         for end in range(len(s)):
             counter[s[end]] = counter.get(s[end], 0) + 1
             max_cnt = max(counter[s[end]], max_cnt)
-            while end - start + 1 - max_cnt > k:
+            if end - start + 1 - max_cnt > k:
                 counter[s[start]] -= 1
                 start += 1
             max_len = max(end - start + 1, max_len)


### PR DESCRIPTION
Longest Repeating Character Replacement 문제 최적화 풀이의 `while`을 `if`로 대체할 수 있어서 제보 드립니다.

`end - start + 1 - max_cnt <= k`가 성립할 때 `end + 1 - start + 1 - max_cnt <= k + 1`이기 때문에 `end`의 값을 Loop Invariant하게 유지하는 동안 `while end - start + 1 - max_cnt > k`이 반복할 때는 `end - start + 1 - max_cnt = k + 1 > k`일 때 1번뿐입니다. 그러면 `start += 1` 이후 바로 `end - start + 1 - max_cnt = k`이 되어 반복 1번만에 조건이 거짓으로 바뀌므로 결국 `if`와 동일한 효과입니다.